### PR TITLE
Fix the vllm link in requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ https://github.com/Dao-AILab/flash-attention/releases/download/v2.5.5/flash_attn
 deepspeed==0.14.1
 triton==2.1.0
 xformers==0.0.23.post1
-https://github.com/McGill-NLP/VinePPO/releases/download/v0.1/vllm-0.4.0.post1-cp310-cp310-linux_x86_64.whl
+https://github.com/McGill-NLP/VinePPO/releases/download/latest/vllm-0.4.0.post1-cp310-cp310-linux_x86_64.whl
 accelerate==0.27.2
 transformers==4.38.1
 tokenizers==0.15.2


### PR DESCRIPTION
I’ve changed the link to point to the `latest` release as the current one does not work (because the **tag** `v0.1` does not in fact have the wheel attached to it).